### PR TITLE
twin topic error fix

### DIFF
--- a/agent/mqtt.py
+++ b/agent/mqtt.py
@@ -65,6 +65,8 @@ class MQTT(Node):
         self.gateway_to_agent_topic = self.get_parameter("gateway_to_agent_topic").value
 
         self.thing_messages_topic = self.get_parameter("thing_messages_topic").value
+        
+        self.twin_topic = f"{self.prefix}/{self.namespace}:{self.name}"
 
         # MQTT Client
         self.mqtt = Client(
@@ -93,9 +95,6 @@ class MQTT(Node):
         )
 
         self.pub_thing = self.create_publisher(Thing, self.thing_messages_topic, 10)
-
-        # Other
-        self.twin_topic = f"{self.prefix}/{self.namespace}:{self.name}"
 
     def __del__(self):
         self.mqtt.loop_stop()


### PR DESCRIPTION
Fix for issue #8.
This problem is caused because twin_topic attribute is created after connection is made. And since twin_topic attribute is accessed on on_connect member function, this causes #8 issue. If some reason connection speed is slow, twin_topic attribute is created after connection can be made so there would be no error.
To fix this issue self.twin_topic has been moved above the mqtt connection line.