### PR TITLE
fix: update target registration payload structure in MutoSymphonyProvider

### DIFF
--- a/muto_agent/symphony/symphony_provider.py
+++ b/muto_agent/symphony/symphony_provider.py
@@ -176,26 +176,28 @@ class MutoSymphonyProvider(BaseNode, SymphonyProvider):
         try:
             # Build target registration payload
             target_payload = {
-                "displayName": symphony.target,
-                "forceRedeploy": True,
-                "topologies": [
-                    {
-                        "bindings": [
-                            {
-                                "role": "muto-agent",
-                                "provider": symphony.provider_name,
-                                "config": {
-                                    "name": "proxy",
-                                    "brokerAddress": symphony.broker_address,
-                                    "clientID": symphony.client_id,
-                                    "requestTopic": f"{symphony.topic_prefix}/{symphony.request_topic}",
-                                    "responseTopic": f"{symphony.topic_prefix}/{symphony.response_topic}",
-                                    "timeoutSeconds": symphony.timeout_seconds,
-                                },
-                            }
-                        ]
-                    }
-                ],
+                "spec": {
+                    "displayName": symphony.target,
+                    "forceRedeploy": True,
+                    "topologies": [
+                        {
+                            "bindings": [
+                                {
+                                    "role": "muto-agent",
+                                    "provider": symphony.provider_name,
+                                    "config": {
+                                        "name": "proxy",
+                                        "brokerAddress": symphony.broker_address,
+                                        "clientID": symphony.client_id,
+                                        "requestTopic": f"{symphony.topic_prefix}/{symphony.request_topic}",
+                                        "responseTopic": f"{symphony.topic_prefix}/{symphony.response_topic}",
+                                        "timeoutSeconds": symphony.timeout_seconds,
+                                    },
+                                }
+                            ]
+                        }
+                    ],
+                }
             }
 
             # Register target using API client


### PR DESCRIPTION
the old body was referring to an old version of symphony sdk. Hence the target registration was failing because of way of handling target registration. This commit addresses that issue by syncing the provider with the latest version of symphony sdk